### PR TITLE
MCC-206934 - use local.properties to handle default username / password for testing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
         versionName "1.0"
         buildConfigField "String", "DEFAULT_USERNAME", properties.getProperty('default.username', '""')
         buildConfigField "String", "DEFAULT_PASSWORD", properties.getProperty('default.password', '""')
-        buildConfigField "String", "DEFAULT_ENVIRONMENT", properties.getProperty('default.environment', '"production"')
+        buildConfigField "boolean", "VALIDATION", properties.getProperty('default.isValidation', "false")
     }
     buildTypes {
         release {

--- a/app/src/main/java/com/sample/appconnectsample/LoginActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/LoginActivity.java
@@ -35,9 +35,14 @@ public class LoginActivity extends AppCompatActivity {
         passwordField = (EditText)findViewById(R.id.login_password_field);
         logInButton = (Button)findViewById(R.id.login_log_in_button);
 
-        // Used for testing purposes - should be left as PRODUCTION in
-        // almost all cases
-        Client.setEnvironment(Client.Environment.valueOf(BuildConfig.DEFAULT_ENVIRONMENT.toUpperCase()));
+        Client.setEnvironment(Client.Environment.PRODUCTION);
+
+        // It is possible to communicate with other environments in the Medidata
+        // Platform (although in most cases Production should be used).
+        if (BuildConfig.VALIDATION) {
+            Client.setEnvironment(Client.Environment.VALIDATION);
+        }
+
         usernameField.setText(BuildConfig.DEFAULT_USERNAME);
         passwordField.setText(BuildConfig.DEFAULT_PASSWORD);
     }


### PR DESCRIPTION
This PR cleans up the way we set a default username / password combo for the sample app. I'll do something similar for iOS. These credentials will have to be revoked when we make this repo public. Once we generate new credentials, this new functionality can be used to allow for a default user. The user will just have to add the following to their local.properties file.

```
default.username="sdk@101.com"
default.password="Password90"
default.environment="validation"
```
