### PR TITLE
MCC-188778 add getting started doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In particular, this project shows how to:
 To get this app up and running:
 
 1. Launch Android Studio and use the "Import project" option.
-2. Add the following lines to your local.properties file, using the credentials provided to you:
+2. Add the following lines to your local.properties file, using the provided Artifactory credentials:
 ```
 artifactory.username=yourusername
 artifactory.password=yourpassword


### PR DESCRIPTION
This PR adds a Getting Started document detailing very basic usage of Babbage. This is should provide a good starting point for developers and can be used along with the more detailed Javadocs.

I will also be adding this document to the appconnect-ios repo, but with Swift code examples (and other minor changes) instead of Java.
