### PR TITLE
[MCC-238763] add self registration to sample

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,5 +48,5 @@ dependencies {
     compile 'com.amazonaws:aws-android-sdk-s3:2.2.13'
 
     // *** AppConnect ***
-    compile 'com.mdsol:babbage:2016.3.0.42@aar'
+    compile 'com.mdsol:babbage:2016.3.0.43@aar'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,5 +48,5 @@ dependencies {
     compile 'com.amazonaws:aws-android-sdk-s3:2.2.13'
 
     // *** AppConnect ***
-    compile 'com.mdsol:babbage:2016.3.0.41@aar'
+    compile 'com.mdsol:babbage:2016.3.0.42@aar'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,13 @@
             </intent-filter>
         </activity>
 
-        <activity android:name=".RegistrationActivity" />
+        <activity android:name=".RegistrationEmailActivity" />
+
+        <activity android:name=".RegistrationPasswordActivity" />
+
+        <activity android:name=".RegistrationSecurityQuestionActivity" />
+
+        <activity android:name=".RegistrationSecurityAnswerActivity" /> 
 
         <activity android:name=".ListActivity" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,8 @@
             </intent-filter>
         </activity>
 
+        <activity android:name=".RegistrationActivity" />
+
         <activity android:name=".ListActivity" />
 
         <activity android:name=".OnePageFormActivity" />

--- a/app/src/main/java/com/sample/appconnectsample/App.java
+++ b/app/src/main/java/com/sample/appconnectsample/App.java
@@ -33,10 +33,18 @@ public class App extends Application {
             1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2};
         Babbage.start(this, Client.Environment.PRODUCTION, "API Token", dir, dir, key, null);
 
+        // It is possible to communicate with other environments in the Medidata
+        // Platform (although in most cases Production should be used).
+        if (BuildConfig.VALIDATION) {
+            Client.setEnvironment(Client.Environment.VALIDATION);
+        }
+
         // *** AppConnect ***
         // The client that will be used to make requests to the backend can be
         // created once and reused as needed throughout the app
         client = ClientFactory.getInstance().getClient(Client.Type.HYBRID);
+
+
 
         // *** AppConnect ***
         // In order for object states to be consistent between views, all UI

--- a/app/src/main/java/com/sample/appconnectsample/LoginActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/LoginActivity.java
@@ -54,8 +54,18 @@ public class LoginActivity extends AppCompatActivity {
     }
 
     public void doRegisterButton(View source) {
-        Intent intent = new Intent(LoginActivity.this, RegistrationActivity.class);
-        startActivity(intent);
+        Intent intent = new Intent(LoginActivity.this, RegistrationEmailActivity.class);
+        startActivityForResult(intent, RegistrationEmailActivity.REGISTRATION_REQUEST, null);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (requestCode == RegistrationEmailActivity.REGISTRATION_REQUEST) {
+            if (resultCode == RESULT_OK) {
+                // The user registered successfully, set the email field
+                usernameField.setText(data.getStringExtra("email"));
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/com/sample/appconnectsample/LoginActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/LoginActivity.java
@@ -60,12 +60,10 @@ public class LoginActivity extends AppCompatActivity {
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == RegistrationEmailActivity.REGISTRATION_REQUEST) {
-            if (resultCode == RESULT_OK) {
-                // The user registered successfully, set the email field, and clear password
-                usernameField.setText(data.getStringExtra("email"));
-                passwordField.setText("");
-            }
+        if (resultCode == RESULT_OK && requestCode == RegistrationEmailActivity.REGISTRATION_REQUEST) {
+            // The user registered successfully, set the email field, and clear password
+            usernameField.setText(data.getStringExtra("email"));
+            passwordField.setText("");
         }
     }
 

--- a/app/src/main/java/com/sample/appconnectsample/LoginActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/LoginActivity.java
@@ -62,8 +62,9 @@ public class LoginActivity extends AppCompatActivity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == RegistrationEmailActivity.REGISTRATION_REQUEST) {
             if (resultCode == RESULT_OK) {
-                // The user registered successfully, set the email field
+                // The user registered successfully, set the email field, and clear password
                 usernameField.setText(data.getStringExtra("email"));
+                passwordField.setText("");
             }
         }
     }

--- a/app/src/main/java/com/sample/appconnectsample/LoginActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/LoginActivity.java
@@ -35,14 +35,6 @@ public class LoginActivity extends AppCompatActivity {
         passwordField = (EditText)findViewById(R.id.login_password_field);
         logInButton = (Button)findViewById(R.id.login_log_in_button);
 
-        Client.setEnvironment(Client.Environment.PRODUCTION);
-
-        // It is possible to communicate with other environments in the Medidata
-        // Platform (although in most cases Production should be used).
-        if (BuildConfig.VALIDATION) {
-            Client.setEnvironment(Client.Environment.VALIDATION);
-        }
-
         usernameField.setText(BuildConfig.DEFAULT_USERNAME);
         passwordField.setText(BuildConfig.DEFAULT_PASSWORD);
     }
@@ -64,6 +56,14 @@ public class LoginActivity extends AppCompatActivity {
             // The user registered successfully, set the email field, and clear password
             usernameField.setText(data.getStringExtra("email"));
             passwordField.setText("");
+
+            passwordField.requestFocus();
+
+            new AlertDialog.Builder(LoginActivity.this).
+                    setTitle(R.string.registration_succeeded_title).
+                    setMessage(R.string.registration_succeeded_message).
+                    setPositiveButton(R.string.ok_button, null).
+                    show();
         }
     }
 

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationActivity.java
@@ -1,115 +1,22 @@
 package com.sample.appconnectsample;
 
-import android.app.AlertDialog;
 import android.content.Intent;
-import android.os.AsyncTask;
-import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-import android.util.Log;
-import android.view.View;
-import android.widget.Button;
-import android.widget.EditText;
-import com.mdsol.babbage.model.Datastore;
-import com.mdsol.babbage.model.DatastoreFactory;
-import com.mdsol.babbage.model.User;
-import com.mdsol.babbage.net.Client;
-import com.mdsol.babbage.net.RequestException;
 
 /**
- * The activity where the user can log in with a username and password.
+ * Created by kbohlmann on 7/21/16.
+ * Simple base class for the dialogue sequence of registration activities.
  */
 public class RegistrationActivity extends AppCompatActivity {
 
-    private static final String TAG = "RegistrationActivity";
-
-    private EditText emailField;
-    private EditText emailConfirmationField;
-    private Button registerButton;
+    public static final int REGISTRATION_REQUEST = 1;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.registration_activity);
-
-        emailField = (EditText)findViewById(R.id.registration_email_field);
-        emailConfirmationField = (EditText)findViewById(R.id.registration_email_confirmation_field);
-        registerButton = (Button)findViewById(R.id.registration_register_button);
-    }
-
-    public void onRegisterButton(View source) {
-        
-        String email = emailField.getText().toString();
-        String emailConfirmation = emailConfirmationField.getText().toString();
-
-        if (!email.equals(emailConfirmation)) {
-            //show error.   
-            return;
-        }
-        
-        new RegisterTask().execute(email);
-    }
-
-    /**
-     * An asynchronous task that registers a new user with the email.
-     */
-    private class RegisterTask extends AsyncTask<String,Void,Void> {
-
-        private long userID;
-        private RequestException exception;
-
-        @Override
-        protected void onPreExecute() {
-            registerButton.setEnabled(false);
-        }
-
-        @Override
-        protected Void doInBackground(String... params) {
-            String email = params[0];
-
-            // *** AppConnect ***
-            // Each secondary thread must create its own datastore instance and
-            // dispose of it when done
-            Datastore datastore = null;
-            try {
-                datastore = DatastoreFactory.create();
-                Client client = App.getClient(RegistrationActivity.this);
-                //User user = client.logIn(datastore, username, password);
-
-                // Babbage objects can't be shared between threads so you must pass
-                // them around by ID instead and the receiving code can get its own
-                // copy from its own datastore
-                // userID = user.getID();
-            }
-            /*
-            catch (RequestException ex) {
-                exception = ex;
-            }
-            */
-
-            finally {
-                if (datastore != null)
-                    datastore.dispose();
-            }
-            return null;
-        }
-
-        @Override
-        protected void onPostExecute(Void aVoid) {
-            registerButton.setEnabled(true);
-
-            if (exception != null) {
-                Log.e(TAG, "The registration task failed", exception);
-                new AlertDialog.Builder(RegistrationActivity.this).
-                    setTitle(R.string.registration_failed_title).
-                    setMessage(R.string.registration_failed_message).
-                    setPositiveButton(R.string.ok_button, null).
-                    show();
-            }
-            else {
-                //segue to login
-                // Intent intent = new Intent(LoginActivity.this, ListActivity.class);
-                // intent.putExtra(ListActivity.USER_ID_EXTRA, userID);
-                // startActivity(intent);
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (requestCode == REGISTRATION_REQUEST) {
+            if (resultCode == RESULT_OK) {
+                setResult(RESULT_OK, data);
+                finish();
             }
         }
     }

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationActivity.java
@@ -29,19 +29,11 @@ public class RegistrationActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.login_activity);
+        setContentView(R.layout.registration_activity);
 
         emailField = (EditText)findViewById(R.id.registration_email_field);
         emailConfirmationField = (EditText)findViewById(R.id.registration_email_confirmation_field);
         registerButton = (Button)findViewById(R.id.registration_register_button);
-
-        Client.setEnvironment(Client.Environment.PRODUCTION);
-
-        // It is possible to communicate with other environments in the Medidata
-        // Platform (although in most cases Production should be used).
-        if (BuildConfig.VALIDATION) {
-            Client.setEnvironment(Client.Environment.VALIDATION);
-        }
     }
 
     public void onRegisterButton(View source) {

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationActivity.java
@@ -14,7 +14,7 @@ public abstract class RegistrationActivity extends AppCompatActivity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == REGISTRATION_REQUEST) {
-            setResult(requestCode, data);
+            setResult(resultCode, data);
             finish();
         }
     }

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationActivity.java
@@ -13,11 +13,9 @@ public abstract class RegistrationActivity extends AppCompatActivity {
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == REGISTRATION_REQUEST) {
-            if (resultCode == RESULT_OK) {
-                setResult(RESULT_OK, data);
-                finish();
-            }
+        if (resultCode == RESULT_OK && requestCode == REGISTRATION_REQUEST) {
+            setResult(RESULT_OK, data);
+            finish();
         }
     }
 }

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationActivity.java
@@ -7,7 +7,7 @@ import android.support.v7.app.AppCompatActivity;
  * Created by kbohlmann on 7/21/16.
  * Simple base class for the dialogue sequence of registration activities.
  */
-public class RegistrationActivity extends AppCompatActivity {
+public abstract class RegistrationActivity extends AppCompatActivity {
 
     public static final int REGISTRATION_REQUEST = 1;
 

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationActivity.java
@@ -18,22 +18,22 @@ import com.mdsol.babbage.net.RequestException;
 /**
  * The activity where the user can log in with a username and password.
  */
-public class LoginActivity extends AppCompatActivity {
+public class RegistrationActivity extends AppCompatActivity {
 
-    private static final String TAG = "LoginActivity";
+    private static final String TAG = "RegistrationActivity";
 
-    private EditText usernameField;
-    private EditText passwordField;
-    private Button logInButton;
+    private EditText emailField;
+    private EditText emailConfirmationField;
+    private Button registerButton;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.login_activity);
 
-        usernameField = (EditText)findViewById(R.id.login_username_field);
-        passwordField = (EditText)findViewById(R.id.login_password_field);
-        logInButton = (Button)findViewById(R.id.login_log_in_button);
+        emailField = (EditText)findViewById(R.id.registration_email_field);
+        emailConfirmationField = (EditText)findViewById(R.id.registration_email_confirmation_field);
+        registerButton = (Button)findViewById(R.id.registration_register_button);
 
         Client.setEnvironment(Client.Environment.PRODUCTION);
 
@@ -42,39 +42,37 @@ public class LoginActivity extends AppCompatActivity {
         if (BuildConfig.VALIDATION) {
             Client.setEnvironment(Client.Environment.VALIDATION);
         }
-
-        usernameField.setText(BuildConfig.DEFAULT_USERNAME);
-        passwordField.setText(BuildConfig.DEFAULT_PASSWORD);
     }
 
-    public void doLogInButton(View source) {
-        String username = usernameField.getText().toString();
-        String password = passwordField.getText().toString();
-        new LogInTask().execute(username, password);
-    }
+    public void onRegisterButton(View source) {
+        
+        String email = emailField.getText().toString();
+        String emailConfirmation = emailConfirmationField.getText().toString();
 
-    public void doRegisterButton(View source) {
-        Intent intent = new Intent(LoginActivity.this, RegistrationActivity.class);
-        startActivity(intent);
+        if (!email.equals(emailConfirmation)) {
+            //show error.   
+            return;
+        }
+        
+        new RegisterTask().execute(email);
     }
 
     /**
-     * An asynchronous task that logs in the user.
+     * An asynchronous task that registers a new user with the email.
      */
-    private class LogInTask extends AsyncTask<String,Void,Void> {
+    private class RegisterTask extends AsyncTask<String,Void,Void> {
 
         private long userID;
         private RequestException exception;
 
         @Override
         protected void onPreExecute() {
-            logInButton.setEnabled(false);
+            registerButton.setEnabled(false);
         }
 
         @Override
         protected Void doInBackground(String... params) {
-            String username = params[0];
-            String password = params[1];
+            String email = params[0];
 
             // *** AppConnect ***
             // Each secondary thread must create its own datastore instance and
@@ -82,17 +80,20 @@ public class LoginActivity extends AppCompatActivity {
             Datastore datastore = null;
             try {
                 datastore = DatastoreFactory.create();
-                Client client = App.getClient(LoginActivity.this);
-                User user = client.logIn(datastore, username, password);
+                Client client = App.getClient(RegistrationActivity.this);
+                //User user = client.logIn(datastore, username, password);
 
                 // Babbage objects can't be shared between threads so you must pass
                 // them around by ID instead and the receiving code can get its own
                 // copy from its own datastore
-                userID = user.getID();
+                // userID = user.getID();
             }
+            /*
             catch (RequestException ex) {
                 exception = ex;
             }
+            */
+
             finally {
                 if (datastore != null)
                     datastore.dispose();
@@ -102,22 +103,21 @@ public class LoginActivity extends AppCompatActivity {
 
         @Override
         protected void onPostExecute(Void aVoid) {
-            logInButton.setEnabled(true);
+            registerButton.setEnabled(true);
 
             if (exception != null) {
-                Log.e(TAG, "The log in task failed", exception);
-                new AlertDialog.Builder(LoginActivity.this).
-                    setTitle(R.string.login_failed_title).
-                    setMessage(R.string.login_failed_message).
+                Log.e(TAG, "The registration task failed", exception);
+                new AlertDialog.Builder(RegistrationActivity.this).
+                    setTitle(R.string.registration_failed_title).
+                    setMessage(R.string.registration_failed_message).
                     setPositiveButton(R.string.ok_button, null).
                     show();
             }
             else {
-                // Start the ListActivity to show the forms available for the
-                // user who just logged in
-                Intent intent = new Intent(LoginActivity.this, ListActivity.class);
-                intent.putExtra(ListActivity.USER_ID_EXTRA, userID);
-                startActivity(intent);
+                //segue to login
+                // Intent intent = new Intent(LoginActivity.this, ListActivity.class);
+                // intent.putExtra(ListActivity.USER_ID_EXTRA, userID);
+                // startActivity(intent);
             }
         }
     }

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationActivity.java
@@ -13,8 +13,8 @@ public abstract class RegistrationActivity extends AppCompatActivity {
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (resultCode == RESULT_OK && requestCode == REGISTRATION_REQUEST) {
-            setResult(RESULT_OK, data);
+        if (requestCode == REGISTRATION_REQUEST) {
+            setResult(requestCode, data);
             finish();
         }
     }

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationEmailActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationEmailActivity.java
@@ -29,31 +29,23 @@ public class RegistrationEmailActivity extends RegistrationActivity {
 
         validate();
 
-        emailField.addTextChangedListener(new TextWatcher() {
+        TextWatcher validationListener = new TextWatcher() {
             @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
 
             @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {}
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
 
             @Override
             public void afterTextChanged(Editable s) {
                 validate();
             }
-        });
+        };
 
-        emailConfirmationField.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
-
-            @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {}
-
-            @Override
-            public void afterTextChanged(Editable s) {
-                validate();
-            }
-        });
+        emailField.addTextChangedListener(validationListener);
+        emailConfirmationField.addTextChangedListener(validationListener);
     }
 
     public void onSubmitButton(View source) {
@@ -66,8 +58,10 @@ public class RegistrationEmailActivity extends RegistrationActivity {
 
         submitButton.setEnabled(false);
 
-        if (emailField.getText().toString().equals(emailConfirmationField.getText().toString()) &&
-                android.util.Patterns.EMAIL_ADDRESS.matcher(emailField.getText().toString()).matches())
+        String email = emailField.getText().toString();
+        String emailConfirmation = emailConfirmationField.getText().toString();
+
+        if (email.equals(emailConfirmation) && android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches())
             submitButton.setEnabled(true);
     }
 }

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationEmailActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationEmailActivity.java
@@ -1,6 +1,5 @@
 package com.sample.appconnectsample;
 
-import android.app.AlertDialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationEmailActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationEmailActivity.java
@@ -54,7 +54,6 @@ public class RegistrationEmailActivity extends RegistrationActivity {
     }
 
     private void validate() {
-
         submitButton.setEnabled(false);
 
         String email = emailField.getText().toString();

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationEmailActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationEmailActivity.java
@@ -1,0 +1,96 @@
+package com.sample.appconnectsample;
+
+import android.app.AlertDialog;
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+
+/**
+ * The activity where the user can log in with a username and password.
+ */
+public class RegistrationEmailActivity extends RegistrationActivity {
+
+    private EditText emailField;
+    private EditText emailConfirmationField;
+    private Button submitButton;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.registration_email_activity);
+
+        emailField = (EditText)findViewById(R.id.registration_email_field);
+        emailConfirmationField = (EditText)findViewById(R.id.registration_email_confirmation_field);
+
+        validate();
+
+        emailField.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                validate();
+            }
+        });
+
+        emailConfirmationField.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                validate();
+            }
+        });
+
+
+    }
+
+    public void onSubmitButton(View source) {
+
+        if (emailField.getText().toString().isEmpty())
+            return;
+
+        if (!emailField.getText().toString().equals(emailConfirmationField.getText().toString())) {
+            new AlertDialog.Builder(RegistrationEmailActivity.this).
+                    setTitle(R.string.registration_email_failed_title).
+                    setMessage(R.string.registration_email_mismatch_message).
+                    setPositiveButton(R.string.ok_button, null).
+                    show();
+            return;
+        }
+
+        // seque to password entry
+        Intent intent = new Intent(RegistrationEmailActivity.this, RegistrationPasswordActivity.class);
+        intent.putExtra("email", emailField.getText().toString());
+        startActivityForResult(intent, RegistrationEmailActivity.REGISTRATION_REQUEST);
+    }
+
+    private void validate() {
+        if(emailField.getText().toString().isEmpty() && emailField.getText().toString().equals(emailConfirmationField.getText().toString())) {
+            submitButton.setEnabled(true);
+        } else {
+            submitButton.setEnabled(false);
+        }
+    }
+
+}

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationEmailActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationEmailActivity.java
@@ -57,23 +57,9 @@ public class RegistrationEmailActivity extends RegistrationActivity {
     }
 
     public void onSubmitButton(View source) {
-
-        if (emailField.getText().toString().isEmpty())
-            return;
-
-        if (!emailField.getText().toString().equals(emailConfirmationField.getText().toString())) {
-            new AlertDialog.Builder(RegistrationEmailActivity.this).
-                    setTitle(R.string.registration_email_failed_title).
-                    setMessage(R.string.registration_email_mismatch_message).
-                    setPositiveButton(R.string.ok_button, null).
-                    show();
-            return;
-        }
-
-        // segue to password entry
         Intent intent = new Intent(RegistrationEmailActivity.this, RegistrationPasswordActivity.class);
         intent.putExtra("email", emailField.getText().toString());
-        startActivityForResult(intent, RegistrationEmailActivity.REGISTRATION_REQUEST);
+        startActivityForResult(intent, REGISTRATION_REQUEST);
     }
 
     private void validate() {

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationEmailActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationEmailActivity.java
@@ -25,19 +25,16 @@ public class RegistrationEmailActivity extends RegistrationActivity {
 
         emailField = (EditText)findViewById(R.id.registration_email_field);
         emailConfirmationField = (EditText)findViewById(R.id.registration_email_confirmation_field);
+        submitButton = (Button)findViewById(R.id.registration_email_submit_button);
 
         validate();
 
         emailField.addTextChangedListener(new TextWatcher() {
             @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-
-            }
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
 
             @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
-
-            }
+            public void onTextChanged(CharSequence s, int start, int before, int count) {}
 
             @Override
             public void afterTextChanged(Editable s) {
@@ -47,22 +44,16 @@ public class RegistrationEmailActivity extends RegistrationActivity {
 
         emailConfirmationField.addTextChangedListener(new TextWatcher() {
             @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-
-            }
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
 
             @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
-
-            }
+            public void onTextChanged(CharSequence s, int start, int before, int count) {}
 
             @Override
             public void afterTextChanged(Editable s) {
                 validate();
             }
         });
-
-
     }
 
     public void onSubmitButton(View source) {
@@ -79,18 +70,18 @@ public class RegistrationEmailActivity extends RegistrationActivity {
             return;
         }
 
-        // seque to password entry
+        // segue to password entry
         Intent intent = new Intent(RegistrationEmailActivity.this, RegistrationPasswordActivity.class);
         intent.putExtra("email", emailField.getText().toString());
         startActivityForResult(intent, RegistrationEmailActivity.REGISTRATION_REQUEST);
     }
 
     private void validate() {
-        if(emailField.getText().toString().isEmpty() && emailField.getText().toString().equals(emailConfirmationField.getText().toString())) {
-            submitButton.setEnabled(true);
-        } else {
-            submitButton.setEnabled(false);
-        }
-    }
 
+        submitButton.setEnabled(false);
+
+        if (emailField.getText().toString().equals(emailConfirmationField.getText().toString()) &&
+                android.util.Patterns.EMAIL_ADDRESS.matcher(emailField.getText().toString()).matches())
+            submitButton.setEnabled(true);
+    }
 }

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationPasswordActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationPasswordActivity.java
@@ -1,0 +1,43 @@
+package com.sample.appconnectsample;
+
+import android.app.AlertDialog;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.EditText;
+
+/**
+ * The activity where the user can log in with a username and password.
+ */
+public class RegistrationPasswordActivity extends RegistrationActivity {
+
+    private EditText passwordField;
+    private EditText passwordConfirmationField;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.registration_password_activity);
+
+        passwordField = (EditText)findViewById(R.id.registration_password_field);
+        passwordConfirmationField = (EditText)findViewById(R.id.registration_password_confirmation_field);
+    }
+
+    public void onSubmitButton(View source) {
+
+        if (!passwordField.getText().toString().equals(passwordConfirmationField.getText().toString())) {
+            new AlertDialog.Builder(RegistrationPasswordActivity.this).
+                    setTitle(R.string.registration_password_failed_title).
+                    setMessage(R.string.registration_password_failed_message).
+                    setPositiveButton(R.string.ok_button, null).
+                    show();
+            return;
+        }
+
+        // activity with result into security question.
+        Intent intent = new Intent(RegistrationPasswordActivity.this, RegistrationEmailActivity.class);
+        intent.putExtra("email", getIntent().getStringExtra("email"));
+        intent.putExtra("password", passwordField.getText().toString());
+        startActivityForResult(intent, RegistrationEmailActivity.REGISTRATION_REQUEST);
+    }
+}

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationPasswordActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationPasswordActivity.java
@@ -33,31 +33,23 @@ public class RegistrationPasswordActivity extends RegistrationActivity {
 
         validate();
 
-        passwordField.addTextChangedListener(new TextWatcher() {
+        TextWatcher validationListener = new TextWatcher() {
             @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
 
             @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {}
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
 
             @Override
             public void afterTextChanged(Editable s) {
                 validate();
             }
-        });
+        };
 
-        passwordConfirmationField.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
-
-            @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {}
-
-            @Override
-            public void afterTextChanged(Editable s) {
-                validate();
-            }
-        });
+        passwordField.addTextChangedListener(validationListener);
+        passwordConfirmationField.addTextChangedListener(validationListener);
     }
 
     public void onSubmitButton(View source) {
@@ -71,8 +63,10 @@ public class RegistrationPasswordActivity extends RegistrationActivity {
 
         submitButton.setEnabled(false);
 
-        if (Pattern.compile(PASSWORD_PATTERN).matcher(passwordField.getText().toString()).matches() &&
-                passwordField.getText().toString().equals(passwordConfirmationField.getText().toString()))
+        String password = passwordField.getText().toString();
+        String passwordConfirmation = passwordConfirmationField.getText().toString();
+
+        if (Pattern.compile(PASSWORD_PATTERN).matcher(password).matches() && password.equals(passwordConfirmation))
             submitButton.setEnabled(true);
     }
 

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationPasswordActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationPasswordActivity.java
@@ -22,7 +22,6 @@ public class RegistrationPasswordActivity extends RegistrationActivity {
 
     final String PASSWORD_PATTERN = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=\\S+$).{8,}$";
 
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -62,11 +61,10 @@ public class RegistrationPasswordActivity extends RegistrationActivity {
     }
 
     public void onSubmitButton(View source) {
-        // activity with result into security question.
-        Intent intent = new Intent(RegistrationPasswordActivity.this, RegistrationEmailActivity.class);
+        Intent intent = new Intent(RegistrationPasswordActivity.this, RegistrationSecurityQuestionActivity.class);
         intent.putExtra("email", getIntent().getStringExtra("email"));
         intent.putExtra("password", passwordField.getText().toString());
-        startActivityForResult(intent, RegistrationSecurityQuestionActivity.REGISTRATION_REQUEST);
+        startActivityForResult(intent, REGISTRATION_REQUEST);
     }
 
     private void validate() {

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationPasswordActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationPasswordActivity.java
@@ -1,6 +1,5 @@
 package com.sample.appconnectsample;
 
-import android.app.AlertDialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationPasswordActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationPasswordActivity.java
@@ -59,7 +59,6 @@ public class RegistrationPasswordActivity extends RegistrationActivity {
     }
 
     private void validate() {
-
         submitButton.setEnabled(false);
 
         String password = passwordField.getText().toString();

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationPasswordActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationPasswordActivity.java
@@ -3,8 +3,13 @@ package com.sample.appconnectsample;
 import android.app.AlertDialog;
 import android.content.Intent;
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.View;
+import android.widget.Button;
 import android.widget.EditText;
+
+import java.util.regex.Pattern;
 
 /**
  * The activity where the user can log in with a username and password.
@@ -13,6 +18,10 @@ public class RegistrationPasswordActivity extends RegistrationActivity {
 
     private EditText passwordField;
     private EditText passwordConfirmationField;
+    private Button submitButton;
+
+    final String PASSWORD_PATTERN = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=\\S+$).{8,}$";
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -21,23 +30,52 @@ public class RegistrationPasswordActivity extends RegistrationActivity {
 
         passwordField = (EditText)findViewById(R.id.registration_password_field);
         passwordConfirmationField = (EditText)findViewById(R.id.registration_password_confirmation_field);
+        submitButton = (Button)findViewById(R.id.registration_submit_password_button);
+
+        validate();
+
+        passwordField.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {}
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                validate();
+            }
+        });
+
+        passwordConfirmationField.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {}
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                validate();
+            }
+        });
     }
 
     public void onSubmitButton(View source) {
-
-        if (!passwordField.getText().toString().equals(passwordConfirmationField.getText().toString())) {
-            new AlertDialog.Builder(RegistrationPasswordActivity.this).
-                    setTitle(R.string.registration_password_failed_title).
-                    setMessage(R.string.registration_password_failed_message).
-                    setPositiveButton(R.string.ok_button, null).
-                    show();
-            return;
-        }
-
         // activity with result into security question.
         Intent intent = new Intent(RegistrationPasswordActivity.this, RegistrationEmailActivity.class);
         intent.putExtra("email", getIntent().getStringExtra("email"));
         intent.putExtra("password", passwordField.getText().toString());
-        startActivityForResult(intent, RegistrationEmailActivity.REGISTRATION_REQUEST);
+        startActivityForResult(intent, RegistrationSecurityQuestionActivity.REGISTRATION_REQUEST);
     }
+
+    private void validate() {
+
+        submitButton.setEnabled(false);
+
+        if (Pattern.compile(PASSWORD_PATTERN).matcher(passwordField.getText().toString()).matches() &&
+                passwordField.getText().toString().equals(passwordConfirmationField.getText().toString()))
+            submitButton.setEnabled(true);
+    }
+
 }

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityAnswerActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityAnswerActivity.java
@@ -1,0 +1,122 @@
+package com.sample.appconnectsample;
+
+import android.app.AlertDialog;
+import android.content.Intent;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import com.mdsol.babbage.model.Datastore;
+import com.mdsol.babbage.model.DatastoreFactory;
+import com.mdsol.babbage.net.Client;
+import com.mdsol.babbage.net.RequestException;
+
+/**
+ * The activity where the user can log in with a username and password.
+ */
+public class RegistrationSecurityAnswerActivity extends RegistrationActivity {
+
+    private static final String TAG = "RegSecAnsActivity";
+
+    private Button submitButton;
+    private EditText securityAnswerField;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.registration_security_answer_activity);
+
+        //securityAnswer = (EditText)findViewById(R.id.);
+        //submitButton =
+    }
+
+    public void onSubmitButton(View source) {
+
+        if (!securityAnswerField.getText().toString().isEmpty()) {
+            new AlertDialog.Builder(RegistrationSecurityAnswerActivity.this).
+                    setTitle(R.string.security_answer_failed_title).
+                    setMessage(R.string.security_answer_failed_message).
+                    setPositiveButton(R.string.ok_button, null).
+                    show();
+            return;
+        }
+
+        // intent should have all the stuff.
+        new RegisterTask().execute(getIntent().getStringExtra("email"),
+                getIntent().getStringExtra("password"),
+                getIntent().getStringExtra("securityQuestion"),
+                getIntent().getStringExtra("securityAnswer"));
+    }
+
+    /**
+     * An asynchronous task that registers a new user with the email.
+     */
+    private class RegisterTask extends AsyncTask<String,Void,Void> {
+
+        private RequestException exception;
+
+        @Override
+        protected void onPreExecute() {
+            submitButton.setEnabled(false);
+        }
+
+        @Override
+        protected Void doInBackground(String... params) {
+            String email = params[0];
+            String password = params[1];
+            String securityQuestion = params[2];
+            String securityAnswer = params[3];
+
+            // *** AppConnect ***
+            // Each secondary thread must create its own datastore instance and
+            // dispose of it when done
+            Datastore datastore = null;
+            try {
+                datastore = DatastoreFactory.create();
+                Client client = App.getClient(RegistrationSecurityAnswerActivity.this);
+                //User user = client.logIn(datastore, username, password);
+
+                // Babbage objects can't be shared between threads so you must pass
+                // them around by ID instead and the receiving code can get its own
+                // copy from its own datastore
+                // userID = user.getID();
+            }
+            /*
+            catch (RequestException ex) {
+                exception = ex;
+            }
+            */
+
+            finally {
+                if (datastore != null)
+                    datastore.dispose();
+            }
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(Void aVoid) {
+
+            if (exception != null) {
+                submitButton.setEnabled(true);
+                Log.e(TAG, "The registration task failed", exception);
+                new AlertDialog.Builder(RegistrationSecurityAnswerActivity.this).
+                        setTitle(R.string.registration_failed_title).
+                        setMessage(exception.getMessage()).
+                        setPositiveButton(R.string.ok_button, null).
+                        show();
+                return;
+            }
+
+            // unwind the whole stack of registration activities back to the login screen,
+            // and populate the login email field.
+            Intent returnIntent = new Intent();
+            returnIntent.putExtra("email", getIntent().getStringExtra("email"));
+
+            setResult(RESULT_OK, returnIntent);
+            finish();
+        }
+    }
+}

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityAnswerActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityAnswerActivity.java
@@ -65,7 +65,7 @@ public class RegistrationSecurityAnswerActivity extends RegistrationActivity {
         createAccountButton.setEnabled(false);
 
         // security answer must be at least 2 characters long.
-        if (securityAnswerField.getText().toString().length() > 2) {
+        if (securityAnswerField.getText().toString().length() >= 2) {
             createAccountButton.setEnabled(true);
         }
     }

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityAnswerActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityAnswerActivity.java
@@ -12,8 +12,6 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
-import com.mdsol.babbage.model.Datastore;
-import com.mdsol.babbage.model.DatastoreFactory;
 import com.mdsol.babbage.net.Client;
 import com.mdsol.babbage.net.RequestException;
 
@@ -27,6 +25,7 @@ public class RegistrationSecurityAnswerActivity extends RegistrationActivity {
     private Button createAccountButton;
     private EditText securityAnswerField;
     private TextView securityQuestionView;
+    private View progressBar;
 
     String emailToRegister;
     String passwordToRegister;
@@ -43,6 +42,9 @@ public class RegistrationSecurityAnswerActivity extends RegistrationActivity {
         createAccountButton = (Button)findViewById(R.id.registration_create_account_button);
 
         securityQuestionView.setText(getIntent().getStringExtra("securityQuestion"));
+
+        progressBar = findViewById(R.id.registration_progress_bar);
+        progressBar.setVisibility(View.GONE);
 
         validate();
 
@@ -90,40 +92,27 @@ public class RegistrationSecurityAnswerActivity extends RegistrationActivity {
         @Override
         protected void onPreExecute() {
             createAccountButton.setEnabled(false);
+            progressBar.setVisibility(View.VISIBLE);
         }
 
         @Override
         protected Void doInBackground(String... params) {
             // *** AppConnect ***
-            // Each secondary thread must create its own datastore instance and
-            // dispose of it when done
-            Datastore datastore = null;
+            // Client call to register the subject. No exception thrown implies success.
             try {
-                datastore = DatastoreFactory.create();
                 Client client = App.getClient(RegistrationSecurityAnswerActivity.this);
-
-                //User user = client.logIn(datastore, username, password);
-
-                // Babbage objects can't be shared between threads so you must pass
-                // them around by ID instead and the receiving code can get its own
-                // copy from its own datastore
-                // userID = user.getID();
+                client.registerSubject(emailToRegister, passwordToRegister, securityQuestionIdToRegister, securityAnswerToRegister);
             }
-            /*
             catch (RequestException ex) {
                 exception = ex;
-            }
-            */
-
-            finally {
-                if (datastore != null)
-                    datastore.dispose();
             }
             return null;
         }
 
         @Override
         protected void onPostExecute(Void aVoid) {
+
+            progressBar.setVisibility(View.GONE);
 
             if (exception != null) {
                 createAccountButton.setEnabled(true);

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityAnswerActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityAnswerActivity.java
@@ -126,7 +126,7 @@ public class RegistrationSecurityAnswerActivity extends RegistrationActivity {
             // the stack of registration activities back to the login screen,
             // and populate the login email field.
             Intent returnIntent = new Intent();
-            returnIntent.putExtra("email", getIntent().getStringExtra("email"));
+            returnIntent.putExtra("email", emailToRegister);
 
             setResult(RESULT_OK, returnIntent);
             finish();

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityAnswerActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityAnswerActivity.java
@@ -63,7 +63,6 @@ public class RegistrationSecurityAnswerActivity extends RegistrationActivity {
     }
 
     private void validate() {
-
         createAccountButton.setEnabled(false);
 
         // security answer must be at least 2 characters long.
@@ -73,7 +72,6 @@ public class RegistrationSecurityAnswerActivity extends RegistrationActivity {
     }
 
     public void onCreateAccountButton(View source) {
-
         emailToRegister = getIntent().getStringExtra("email");
         passwordToRegister = getIntent().getStringExtra("password");
         securityAnswerToRegister = securityAnswerField.getText().toString();
@@ -111,7 +109,6 @@ public class RegistrationSecurityAnswerActivity extends RegistrationActivity {
 
         @Override
         protected void onPostExecute(Void aVoid) {
-
             progressBar.setVisibility(View.GONE);
 
             if (exception != null) {

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityAnswerActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityAnswerActivity.java
@@ -28,6 +28,11 @@ public class RegistrationSecurityAnswerActivity extends RegistrationActivity {
     private EditText securityAnswerField;
     private TextView securityQuestionView;
 
+    String emailToRegister;
+    String passwordToRegister;
+    int securityQuestionIdToRegister;
+    String securityAnswerToRegister;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -59,20 +64,24 @@ public class RegistrationSecurityAnswerActivity extends RegistrationActivity {
 
         createAccountButton.setEnabled(false);
 
-        if (!securityAnswerField.getText().toString().isEmpty()) {
+        // security answer must be at least 2 characters long.
+        if (securityAnswerField.getText().toString().length() > 2) {
             createAccountButton.setEnabled(true);
         }
     }
 
     public void onCreateAccountButton(View source) {
-        new RegisterTask().execute(getIntent().getStringExtra("email"),
-                getIntent().getStringExtra("password"),
-                getIntent().getStringExtra("securityQuestion"),
-                getIntent().getStringExtra("securityAnswer"));
+
+        emailToRegister = getIntent().getStringExtra("email");
+        passwordToRegister = getIntent().getStringExtra("password");
+        securityAnswerToRegister = securityAnswerField.getText().toString();
+        securityQuestionIdToRegister = getIntent().getIntExtra("securityQuestionId", 0);
+
+        new RegisterTask().execute();
     }
 
     /**
-     * An asynchronous task that registers a new user with the email.
+     * An asynchronous task that registers a new user.
      */
     private class RegisterTask extends AsyncTask<String,Void,Void> {
 
@@ -85,11 +94,6 @@ public class RegistrationSecurityAnswerActivity extends RegistrationActivity {
 
         @Override
         protected Void doInBackground(String... params) {
-            String email = params[0];
-            String password = params[1];
-            String securityQuestion = params[2];
-            String securityAnswer = params[3];
-
             // *** AppConnect ***
             // Each secondary thread must create its own datastore instance and
             // dispose of it when done
@@ -97,6 +101,7 @@ public class RegistrationSecurityAnswerActivity extends RegistrationActivity {
             try {
                 datastore = DatastoreFactory.create();
                 Client client = App.getClient(RegistrationSecurityAnswerActivity.this);
+
                 //User user = client.logIn(datastore, username, password);
 
                 // Babbage objects can't be shared between threads so you must pass

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityAnswerActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityAnswerActivity.java
@@ -4,10 +4,14 @@ import android.app.AlertDialog;
 import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.TextView;
+
 import com.mdsol.babbage.model.Datastore;
 import com.mdsol.babbage.model.DatastoreFactory;
 import com.mdsol.babbage.net.Client;
@@ -20,30 +24,47 @@ public class RegistrationSecurityAnswerActivity extends RegistrationActivity {
 
     private static final String TAG = "RegSecAnsActivity";
 
-    private Button submitButton;
+    private Button createAccountButton;
     private EditText securityAnswerField;
+    private TextView securityQuestionView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.registration_security_answer_activity);
 
-        //securityAnswer = (EditText)findViewById(R.id.);
-        //submitButton =
+        securityAnswerField = (EditText)findViewById(R.id.registration_security_answer_field);
+        securityQuestionView = (TextView)findViewById(R.id.registration_security_answer_prompt_view);
+        createAccountButton = (Button)findViewById(R.id.registration_create_account_button);
+
+        securityQuestionView.setText(getIntent().getStringExtra("securityQuestion"));
+
+        validate();
+
+        securityAnswerField.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {}
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                validate();
+            }
+        });
     }
 
-    public void onSubmitButton(View source) {
+    private void validate() {
+
+        createAccountButton.setEnabled(false);
 
         if (!securityAnswerField.getText().toString().isEmpty()) {
-            new AlertDialog.Builder(RegistrationSecurityAnswerActivity.this).
-                    setTitle(R.string.security_answer_failed_title).
-                    setMessage(R.string.security_answer_failed_message).
-                    setPositiveButton(R.string.ok_button, null).
-                    show();
-            return;
+            createAccountButton.setEnabled(true);
         }
+    }
 
-        // intent should have all the stuff.
+    public void onCreateAccountButton(View source) {
         new RegisterTask().execute(getIntent().getStringExtra("email"),
                 getIntent().getStringExtra("password"),
                 getIntent().getStringExtra("securityQuestion"),
@@ -59,7 +80,7 @@ public class RegistrationSecurityAnswerActivity extends RegistrationActivity {
 
         @Override
         protected void onPreExecute() {
-            submitButton.setEnabled(false);
+            createAccountButton.setEnabled(false);
         }
 
         @Override
@@ -100,7 +121,7 @@ public class RegistrationSecurityAnswerActivity extends RegistrationActivity {
         protected void onPostExecute(Void aVoid) {
 
             if (exception != null) {
-                submitButton.setEnabled(true);
+                createAccountButton.setEnabled(true);
                 Log.e(TAG, "The registration task failed", exception);
                 new AlertDialog.Builder(RegistrationSecurityAnswerActivity.this).
                         setTitle(R.string.registration_failed_title).
@@ -110,7 +131,8 @@ public class RegistrationSecurityAnswerActivity extends RegistrationActivity {
                 return;
             }
 
-            // unwind the whole stack of registration activities back to the login screen,
+            // registration succeeded, will now unwind
+            // the stack of registration activities back to the login screen,
             // and populate the login email field.
             Intent returnIntent = new Intent();
             returnIntent.putExtra("email", getIntent().getStringExtra("email"));

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityQuestionActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityQuestionActivity.java
@@ -83,7 +83,6 @@ public class RegistrationSecurityQuestionActivity extends RegistrationActivity {
 
         @Override
         protected void onPreExecute() {
-            // show loading spinner
             progressBar.setVisibility(View.VISIBLE);
         }
 
@@ -107,8 +106,6 @@ public class RegistrationSecurityQuestionActivity extends RegistrationActivity {
 
         @Override
         protected void onPostExecute(Void aVoid) {
-
-            // hide loading spinner
             progressBar.setVisibility(View.GONE);
 
             if (exception != null) {

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityQuestionActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityQuestionActivity.java
@@ -33,17 +33,16 @@ public class RegistrationSecurityQuestionActivity extends RegistrationActivity {
         securityQuestionListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                String selectedQuestion = (String) securityQuestionListView.getAdapter().getItem(position);
-                onSecurityQuestionSelected(selectedQuestion);
+                onSecurityQuestionSelected(position);
             }
         });
     }
 
-    public void onSecurityQuestionSelected(String securityQuestion) {
+    public void onSecurityQuestionSelected(int questionId) {
         Intent intent = new Intent(RegistrationSecurityQuestionActivity.this, RegistrationSecurityAnswerActivity.class);
         intent.putExtra("email", getIntent().getStringExtra("email"));
         intent.putExtra("password", getIntent().getStringExtra("password"));
-        intent.putExtra("securityQuestion", securityQuestion);
+        intent.putExtra("securityQuestionId", questionId);
         startActivityForResult(intent, REGISTRATION_REQUEST);
     }
 }

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityQuestionActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityQuestionActivity.java
@@ -2,26 +2,48 @@ package com.sample.appconnectsample;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ListAdapter;
+import android.widget.ListView;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The activity where the user can log in with a username and password.
  */
 public class RegistrationSecurityQuestionActivity extends RegistrationActivity {
 
+    private ListView securityQuestionListView;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.registration_security_question_activity);
+
+        securityQuestionListView = (ListView)findViewById(R.id.registration_security_question_list_view);
+
+        String[] questions = getResources().getStringArray(R.array.security_questions);
+        ArrayAdapter<String> arrayAdapter = new ArrayAdapter<>(
+                this, android.R.layout.simple_list_item_1, questions );
+        securityQuestionListView.setAdapter(arrayAdapter);
+
+        securityQuestionListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                String selectedQuestion = (String) securityQuestionListView.getAdapter().getItem(position);
+                onSecurityQuestionSelected(selectedQuestion);
+            }
+        });
     }
 
-    // selection from table.
-    public void onSelection() {
-        // activity with result into security question.
-        String securityQuestion = "";
+    public void onSecurityQuestionSelected(String securityQuestion) {
         Intent intent = new Intent(RegistrationSecurityQuestionActivity.this, RegistrationSecurityAnswerActivity.class);
         intent.putExtra("email", getIntent().getStringExtra("email"));
         intent.putExtra("password", getIntent().getStringExtra("password"));
         intent.putExtra("securityQuestion", securityQuestion);
-        startActivityForResult(intent, RegistrationSecurityAnswerActivity.REGISTRATION_REQUEST);
+        startActivityForResult(intent, REGISTRATION_REQUEST);
     }
 }

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityQuestionActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityQuestionActivity.java
@@ -90,8 +90,7 @@ public class RegistrationSecurityQuestionActivity extends RegistrationActivity {
         @Override
         protected Void doInBackground(String... params) {
             // *** AppConnect ***
-            // Each secondary thread must create its own datastore instance and
-            // dispose of it when done
+            // Request the subject registration security questions and their ids.
             try {
                 Client client = App.getClient(RegistrationSecurityQuestionActivity.this);
 

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityQuestionActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityQuestionActivity.java
@@ -1,0 +1,27 @@
+package com.sample.appconnectsample;
+
+import android.content.Intent;
+import android.os.Bundle;
+
+/**
+ * The activity where the user can log in with a username and password.
+ */
+public class RegistrationSecurityQuestionActivity extends RegistrationActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.registration_security_question_activity);
+    }
+
+    // selection from table.
+    public void onSelection() {
+        // activity with result into security question.
+        String securityQuestion = "";
+        Intent intent = new Intent(RegistrationSecurityQuestionActivity.this, RegistrationSecurityAnswerActivity.class);
+        intent.putExtra("email", getIntent().getStringExtra("email"));
+        intent.putExtra("password", getIntent().getStringExtra("password"));
+        intent.putExtra("securityQuestion", securityQuestion);
+        startActivityForResult(intent, RegistrationEmailActivity.REGISTRATION_REQUEST);
+    }
+}

--- a/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityQuestionActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/RegistrationSecurityQuestionActivity.java
@@ -22,6 +22,6 @@ public class RegistrationSecurityQuestionActivity extends RegistrationActivity {
         intent.putExtra("email", getIntent().getStringExtra("email"));
         intent.putExtra("password", getIntent().getStringExtra("password"));
         intent.putExtra("securityQuestion", securityQuestion);
-        startActivityForResult(intent, RegistrationEmailActivity.REGISTRATION_REQUEST);
+        startActivityForResult(intent, RegistrationSecurityAnswerActivity.REGISTRATION_REQUEST);
     }
 }

--- a/app/src/main/res/layout/login_activity.xml
+++ b/app/src/main/res/layout/login_activity.xml
@@ -25,13 +25,31 @@
         android:hint="@string/login_password_field_hint"
         android:inputType="textPassword" />
 
-    <Button
-        android:id="@+id/login_log_in_button"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/login_password_field"
-        android:layout_marginTop="8dp"
-        android:text="@string/login_log_in_button"
-        android:onClick="doLogInButton" />
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/login_log_in_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_weight="1.0"
+            android:text="@string/login_log_in_button"
+            android:onClick="doLogInButton" />
+
+        <Button
+            android:id="@+id/login_register_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_weight="1.0"
+            android:text="@string/login_register_button"
+            android:onClick="doRegisterButton" />
+
+    </LinearLayout>
+
 
 </RelativeLayout>

--- a/app/src/main/res/layout/registration_activity.xml
+++ b/app/src/main/res/layout/registration_activity.xml
@@ -19,6 +19,8 @@
         android:id="@+id/registration_email_confirmation_field"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_below="@id/registration_email_field"
+        android:layout_marginTop="8dp"
         android:background="@drawable/edit_text_background"
         android:hint="@string/registration_email_confirmation_field_hint"
         android:inputType="text|textEmailAddress" />

--- a/app/src/main/res/layout/registration_activity.xml
+++ b/app/src/main/res/layout/registration_activity.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="20dp"
+    tools:context=".RegistrationActivity">
+
+    <EditText
+        android:id="@+id/registration_email_field"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/edit_text_background"
+        android:hint="@string/registration_email_field_hint"
+        android:inputType="text|textEmailAddress" />
+
+    <EditText
+        android:id="@+id/registration_email_confirmation_field"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/edit_text_background"
+        android:hint="@string/registration_email_confirmation_field_hint"
+        android:inputType="text|textEmailAddress" />
+
+    <Button
+        android:id="@+id/registration_register_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/registration_email_confirmation_field"
+        android:layout_marginTop="8dp"
+        android:text="@string/registration_register_button"
+        android:onClick="onRegisterButton" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/registration_email_activity.xml
+++ b/app/src/main/res/layout/registration_email_activity.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="20dp"
+    tools:context=".RegistrationEmailActivity">
+
+    <EditText
+        android:id="@+id/registration_email_field"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/edit_text_background"
+        android:hint="@string/registration_email_field_hint"
+        android:inputType="text|textEmailAddress" />
+
+    <EditText
+        android:id="@+id/registration_email_confirmation_field"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/registration_email_field"
+        android:layout_marginTop="8dp"
+        android:background="@drawable/edit_text_background"
+        android:hint="@string/registration_email_confirmation_field_hint"
+        android:inputType="text|textEmailAddress" />
+
+    <Button
+        android:id="@+id/registration_email_submit_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/registration_email_confirmation_field"
+        android:layout_marginTop="8dp"
+        android:text="@string/registration_submit_button"
+        android:onClick="onSubmitButton" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/registration_password_activity.xml
+++ b/app/src/main/res/layout/registration_password_activity.xml
@@ -7,19 +7,29 @@
     android:padding="20dp"
     tools:context=".RegistrationPasswordActivity">
 
+    <TextView
+        android:id="@+id/registration_password_prompt_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:textStyle="bold"
+        android:text="@string/registration_password_prompt" />
+
     <EditText
         android:id="@+id/registration_password_field"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@drawable/edit_text_background"
         android:hint="@string/registration_password_field_hint"
+        android:layout_below="@id/registration_password_prompt_view"
+        android:layout_marginTop="8dp"
         android:inputType="textPassword" />
 
     <EditText
         android:id="@+id/registration_password_confirmation_field"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/registration_email_field"
+        android:layout_below="@id/registration_password_field"
         android:layout_marginTop="8dp"
         android:background="@drawable/edit_text_background"
         android:hint="@string/registration_password_confirmation_field_hint"
@@ -29,9 +39,27 @@
         android:id="@+id/registration_submit_password_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/registration_email_confirmation_field"
+        android:layout_below="@id/registration_password_confirmation_field"
         android:layout_marginTop="8dp"
         android:text="@string/registration_submit_button"
         android:onClick="onSubmitButton" />
+
+    <TextView
+        android:id="@+id/registration_password_rules_header_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:textStyle="bold"
+        android:layout_below="@id/registration_submit_password_button"
+        android:layout_marginTop="8dp"
+        android:text="@string/registration_password_rules_header" />
+
+    <TextView
+        android:id="@+id/registration_password_rules_body_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:layout_below="@id/registration_password_rules_header_view"
+        android:text="@string/registration_password_rules_body" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/registration_password_activity.xml
+++ b/app/src/main/res/layout/registration_password_activity.xml
@@ -5,33 +5,33 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="20dp"
-    tools:context=".RegistrationActivity">
+    tools:context=".RegistrationPasswordActivity">
 
     <EditText
-        android:id="@+id/registration_email_field"
+        android:id="@+id/registration_password_field"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@drawable/edit_text_background"
-        android:hint="@string/registration_email_field_hint"
-        android:inputType="text|textEmailAddress" />
+        android:hint="@string/registration_password_field_hint"
+        android:inputType="textPassword" />
 
     <EditText
-        android:id="@+id/registration_email_confirmation_field"
+        android:id="@+id/registration_password_confirmation_field"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/registration_email_field"
         android:layout_marginTop="8dp"
         android:background="@drawable/edit_text_background"
-        android:hint="@string/registration_email_confirmation_field_hint"
-        android:inputType="text|textEmailAddress" />
-
+        android:hint="@string/registration_password_confirmation_field_hint"
+        android:inputType="textPassword" />
+    
     <Button
-        android:id="@+id/registration_register_button"
+        android:id="@+id/registration_submit_password_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/registration_email_confirmation_field"
         android:layout_marginTop="8dp"
-        android:text="@string/registration_register_button"
-        android:onClick="onRegisterButton" />
+        android:text="@string/registration_submit_button"
+        android:onClick="onSubmitButton" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/registration_security_answer_activity.xml
+++ b/app/src/main/res/layout/registration_security_answer_activity.xml
@@ -7,7 +7,30 @@
     android:padding="20dp"
     tools:context=".RegistrationSecurityAnswerActivity">
 
+    <TextView
+        android:id="@+id/registration_security_answer_prompt_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:textStyle="bold" />
 
-    <!--just the string entry and prompt label.-->
+    <EditText
+        android:id="@+id/registration_security_answer_field"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/edit_text_background"
+        android:hint="@string/security_answer_field_hint"
+        android:layout_below="@id/registration_security_answer_prompt_view"
+        android:layout_marginTop="8dp"
+        android:inputType="text" />
+
+    <Button
+        android:id="@+id/registration_create_account_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/registration_security_answer_field"
+        android:layout_marginTop="8dp"
+        android:text="@string/security_answer_button"
+        android:onClick="onCreateAccountButton" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/registration_security_answer_activity.xml
+++ b/app/src/main/res/layout/registration_security_answer_activity.xml
@@ -11,7 +11,7 @@
         android:id="@+id/registration_progress_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
+        android:layout_alignParentBottom="true"
         android:paddingLeft="20dp"
         android:paddingRight="20dp"
         android:paddingTop="8dp"
@@ -40,9 +40,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_horizontal"
-        android:textStyle="bold"
-        android:layout_below="@id/registration_progress_bar"
-        android:layout_marginTop="8dp" />
+        android:textStyle="bold" />
 
     <EditText
         android:id="@+id/registration_security_answer_field"

--- a/app/src/main/res/layout/registration_security_answer_activity.xml
+++ b/app/src/main/res/layout/registration_security_answer_activity.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="20dp"
+    tools:context=".RegistrationSecurityAnswerActivity">
+
+
+    <!--just the string entry and prompt label.-->
+
+</RelativeLayout>

--- a/app/src/main/res/layout/registration_security_answer_activity.xml
+++ b/app/src/main/res/layout/registration_security_answer_activity.xml
@@ -7,12 +7,42 @@
     android:padding="20dp"
     tools:context=".RegistrationSecurityAnswerActivity">
 
+    <RelativeLayout
+        android:id="@+id/registration_progress_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:paddingLeft="20dp"
+        android:paddingRight="20dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:background="@color/colorSecondaryBackground"
+        android:gravity="center_vertical">
+
+        <ProgressBar
+            android:id="@+id/registration_progress_wheel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentRight="true"
+            style="?android:attr/android:progressBarStyleSmall" />
+
+        <TextView
+            android:id="@+id/registration_progress_label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_toLeftOf="@id/list_progress_wheel"
+            android:text="@string/registration_submitted_message" />
+
+    </RelativeLayout>
+
     <TextView
         android:id="@+id/registration_security_answer_prompt_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_horizontal"
-        android:textStyle="bold" />
+        android:textStyle="bold"
+        android:layout_below="@id/registration_progress_bar"
+        android:layout_marginTop="8dp" />
 
     <EditText
         android:id="@+id/registration_security_answer_field"

--- a/app/src/main/res/layout/registration_security_question_activity.xml
+++ b/app/src/main/res/layout/registration_security_question_activity.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="20dp"
+    tools:context=".RegistrationSecurityQuestionActivity">
+
+  <!--just gonna have a single label and a table, no button.
+    need a single string, @string/security_question_selection_prompt-->
+
+
+</RelativeLayout>

--- a/app/src/main/res/layout/registration_security_question_activity.xml
+++ b/app/src/main/res/layout/registration_security_question_activity.xml
@@ -7,12 +7,42 @@
     android:padding="20dp"
     tools:context=".RegistrationSecurityQuestionActivity">
 
+    <RelativeLayout
+        android:id="@+id/questions_progress_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:paddingLeft="20dp"
+        android:paddingRight="20dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:background="@color/colorSecondaryBackground"
+        android:gravity="center_vertical">
+
+        <ProgressBar
+            android:id="@+id/questions_progress_wheel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentRight="true"
+            style="?android:attr/android:progressBarStyleSmall" />
+
+        <TextView
+            android:id="@+id/questions_progress_label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_toLeftOf="@id/list_progress_wheel"
+            android:text="@string/security_question_loading_message" />
+
+    </RelativeLayout>
+
     <TextView
         android:id="@+id/registration_security_question_prompt_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_horizontal"
         android:textStyle="bold"
+        android:layout_below="@+id/questions_progress_bar"
+        android:layout_marginTop="8dp"
         android:text="@string/security_question_selection_prompt" />
 
     <ListView

--- a/app/src/main/res/layout/registration_security_question_activity.xml
+++ b/app/src/main/res/layout/registration_security_question_activity.xml
@@ -7,8 +7,21 @@
     android:padding="20dp"
     tools:context=".RegistrationSecurityQuestionActivity">
 
-  <!--just gonna have a single label and a table, no button.
-    need a single string, @string/security_question_selection_prompt-->
+    <TextView
+        android:id="@+id/registration_security_question_prompt_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:textStyle="bold"
+        android:text="@string/security_question_selection_prompt" />
+
+    <ListView
+        android:id="@+id/registration_security_question_list_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/registration_security_question_prompt_view"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="20dp" />
 
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="login_username_field_hint">Username</string>
     <string name="login_password_field_hint">Password</string>
     <string name="login_log_in_button">Log In</string>
+    <string name="login_register_button">Sign Up</string>
 
     <string name="one_page_form_submit_button">Submit</string>
     <string name="one_page_form_submitting_message">Sending Form…</string>
@@ -52,4 +53,10 @@
 
     <string name="sync_failed_title">Load Failed</string>
     <string name="sync_failed_message">An error occurred while loading the subjects and forms.</string>
+
+    <string name="registration_email_field_hint">Email</string>
+    <string name="registration_email_confirmation_field_hint">Email confirmation</string>
+    <string name="registration_register_button">Submit</string>
+    <string name="registration_failed_title">Registration Failed</string>
+    <string name="registration_failed_message">Enter a valid email</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,8 +59,6 @@
     
     <string name="registration_email_field_hint">Email</string>
     <string name="registration_email_confirmation_field_hint">Email confirmation</string>
-    <string name="registration_email_failed_title">Invalid Email</string>
-    <string name="registration_email_mismatch_message">Emails do not match.</string>
 
     <string name="registration_password_prompt">Enter and confirm a new password:</string>
     <string name="registration_password_field_hint">Password</string>
@@ -69,9 +67,21 @@
     <string name="registration_password_rules_body"> - At least 8 characters long\n - At least one upper-case letter\n - At least one lower-case letter\n - At least one numberic digit</string>
 
     <string name="security_question_selection_prompt">Select a security question:</string>
+    <string-array name="security_questions">
+        <item>What year were you born?</item>
+        <item>Last four digits of SSN or Tax ID number?</item>
+        <item>What is your father\'s middle name?</item>
+        <item>What was the name of your first school?</item>
+        <item>Who was your childhood her?</item>
+        <item>What is your favorite pastime?</item>
+        <item>What is your all-time favorite sports team?</item>
+        <item>What is your high school team or mascot?</item>
+        <item>What make was your first car or bike?</item>
+        <item>What is your pet\'s name?</item>
+        <item>What is your mother\'s middle name?</item>
+    </string-array>
 
+    <string name="security_answer_field_hint">Answer</string>
     <string name="security_answer_button">Create Account</string>
-    <string name="security_answer_failed_title">Invalid Security Answer</string>
-    <string name="security_answer_failed_message">Please enter a valid security answer.</string>
-    
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,9 +54,24 @@
     <string name="sync_failed_title">Load Failed</string>
     <string name="sync_failed_message">An error occurred while loading the subjects and forms.</string>
 
+    <string name="registration_submit_button">Submit</string>
+    <string name="registration_failed_title">Registration Failed</string>
+    
     <string name="registration_email_field_hint">Email</string>
     <string name="registration_email_confirmation_field_hint">Email confirmation</string>
-    <string name="registration_register_button">Submit</string>
-    <string name="registration_failed_title">Registration Failed</string>
-    <string name="registration_failed_message">Enter a valid email</string>
+    <string name="registration_email_failed_title">Invalid Email</string>
+    <string name="registration_email_mismatch_message">Emails do not match.</string>
+
+    <string name="registration_password_prompt">Enter and confirm a new password.</string>
+    <string name="registration_password_field_hint">Password</string>
+    <string name="registration_password_confirmation_field_hint">Password confirmation</string>
+    <string name="registration_password_failed_title">Password Entry Failed</string>
+    <string name="registration_password_failed_message">Passwords do not match.</string>
+
+    <string name="security_question_selection_prompt">Select a security question:</string>
+
+    <string name="security_answer_button">Create Account</string>
+    <string name="security_answer_failed_title">Invalid Security Answer</string>
+    <string name="security_answer_failed_message">Please enter a valid security answer.</string>
+    
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,22 +67,11 @@
     <string name="registration_password_rules_body"> - At least 8 characters long\n - At least one upper-case letter\n - At least one lower-case letter\n - At least one numberic digit</string>
 
     <string name="security_question_selection_prompt">Select a security question:</string>
-    <string-array name="security_questions">
-        <item>What year were you born?</item>
-        <item>Last four digits of SSN or Tax ID number?</item>
-        <item>What is your father\'s middle name?</item>
-        <item>What was the name of your first school?</item>
-        <item>Who was your childhood her?</item>
-        <item>What is your favorite pastime?</item>
-        <item>What is your all-time favorite sports team?</item>
-        <item>What is your high school team or mascot?</item>
-        <item>What make was your first car or bike?</item>
-        <item>What is your pet\'s name?</item>
-        <item>What is your mother\'s middle name?</item>
-    </string-array>
+    <string name="security_question_loading_message">Loading security questions...</string>
 
     <string name="security_answer_field_hint">Answer</string>
     <string name="security_answer_button">Create Account</string>
+    <string name="registration_submitted_message">Registering subject...</string>
 
     <string name="image_capture_header_label">Save an image to AppConnect</string>
     <string name="image_capture_submit_button">Submit</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,11 +62,11 @@
     <string name="registration_email_failed_title">Invalid Email</string>
     <string name="registration_email_mismatch_message">Emails do not match.</string>
 
-    <string name="registration_password_prompt">Enter and confirm a new password.</string>
+    <string name="registration_password_prompt">Enter and confirm a new password:</string>
     <string name="registration_password_field_hint">Password</string>
     <string name="registration_password_confirmation_field_hint">Password confirmation</string>
-    <string name="registration_password_failed_title">Password Entry Failed</string>
-    <string name="registration_password_failed_message">Passwords do not match.</string>
+    <string name="registration_password_rules_header">Passwords must meet the below criteria:</string>
+    <string name="registration_password_rules_body"> - At least 8 characters long\n - At least one upper-case letter\n - At least one lower-case letter\n - At least one numberic digit</string>
 
     <string name="security_question_selection_prompt">Select a security question:</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,8 @@
     <string name="security_answer_field_hint">Answer</string>
     <string name="security_answer_button">Create Account</string>
     <string name="registration_submitted_message">Registering subject...</string>
+    <string name="registration_succeeded_title">Subject registration successful</string>
+    <string name="registration_succeeded_message">Please enter your password to login.</string>
 
     <string name="image_capture_header_label">Save an image to AppConnect</string>
     <string name="image_capture_submit_button">Submit</string>


### PR DESCRIPTION
Self registration added to Android AppConnect sample app. 

Fairly straightforward interactive wizard, a single activity per question, successful registration unwinds this stack back to the login screen and populates the login field, and clears the password field. 

A few inconsistencies from the ios app : 
 we fetch the security questions via appconnect api, in ios they are hardcoded. (we should fix this is in ios)
 we pre validate the fields with specific requirements, rather than raise an alert for incorrect entries, this applies to email entry, password entry, and security question answer entry.

We don't use the isRegistrationActive API call in either sample app, not sure if we want to add that.

This should be good to go, pending testing registration with a valid sandbox token I'll remove the dnm label.
