### PR TITLE
[MCC-242424] limit thumbnail size

### DIFF
--- a/app/src/main/res/layout/image_capture_activity.xml
+++ b/app/src/main/res/layout/image_capture_activity.xml
@@ -18,11 +18,15 @@
         <ImageView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:scaleType="centerInside"
+            android:adjustViewBounds="true"
             android:id="@+id/currentThumbnail"
             android:layout_centerHorizontal="true"
             android:layout_below="@+id/imageCaptureLabel"
             android:minHeight="200dp"
-            android:minWidth="200dp" />
+            android:minWidth="200dp"
+            android:maxHeight="300dp"
+            android:maxWidth="300dp"/>
 
         <LinearLayout
             android:orientation="vertical"


### PR DESCRIPTION
Selecting an image from the device library would then display that image in a thumbnail too large for the screen, forcing the submit and selection buttons off the screen bottom. 

These changes ensure that the thumbnail is kept to a limited size and is scaled and resized appropriately. 
