### PR TITLE
MCC-245346 - show error when user is not associated with specified token

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,5 +50,5 @@ dependencies {
     compile 'com.amazonaws:aws-android-sdk-s3:2.2.13'
 
     // *** AppConnect ***
-    compile 'com.mdsol:babbage:2016.3.0.48@aar'
+    compile 'com.mdsol:babbage:2016.3.0.58@aar'
 }

--- a/app/src/main/java/com/sample/appconnectsample/LoginActivity.java
+++ b/app/src/main/java/com/sample/appconnectsample/LoginActivity.java
@@ -115,9 +115,14 @@ public class LoginActivity extends AppCompatActivity {
 
             if (exception != null) {
                 Log.e(TAG, "The log in task failed", exception);
+                int message = R.string.login_failed_message;
+
+                if (exception.getErrorCause() == RequestException.ErrorCause.USER_NOT_ASSOCIATED_WITH_TOKEN)
+                    message = R.string.login_user_not_associated_message;
+
                 new AlertDialog.Builder(LoginActivity.this).
                     setTitle(R.string.login_failed_title).
-                    setMessage(R.string.login_failed_message).
+                    setMessage(message).
                     setPositiveButton(R.string.ok_button, null).
                     show();
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
 
     <string name="login_failed_title">Login Failed</string>
     <string name="login_failed_message">Please verify your credentials and try again.</string>
+    <string name="login_user_not_associated_message">User is not associated with provided API token</string>
 
     <string name="submit_failed_title">Submit Failed</string>
     <string name="submit_failed_message">An error occurred while sending the form responses.</string>


### PR DESCRIPTION
This PR adds the error handling for the case where the authenticated user is not associated with the specified API token.
